### PR TITLE
fix: コンソール出力の文字コードをUTF8に修正

### DIFF
--- a/Img2WebP/Program.cs
+++ b/Img2WebP/Program.cs
@@ -13,6 +13,7 @@ namespace Img2WebP
 
         static void Main(string[] args)
         {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
             Console.WriteLine($"Img2WebP");
 
             if (args.Length == 0) return;


### PR DESCRIPTION
稀にコンソール出力時に文字化けすることがあったので、コンソール出力時の文字コードをUTF8に修正。